### PR TITLE
Helpful UI Tweaks and Very Minor Fixes

### DIFF
--- a/Editor/VRAM Check/TextureVRAM.cs
+++ b/Editor/VRAM Check/TextureVRAM.cs
@@ -376,27 +376,25 @@ namespace Thry.AvatarHelpers
                                 EditorGUILayout.ObjectField(texInfo.texture, typeof(Texture), false);
                                 EditorGUILayout.LabelField(texInfo.print, GUILayout.Width(100));
                                 EditorGUILayout.LabelField($"({texInfo.format})", GUILayout.Width(100));
-                                if(texInfo.texture is Texture2D && texInfo.BPP > texInfo.minBPP)
+
+                                if(texInfo.format.Length > 0 && texInfo.texture is Texture2D && texInfo.BPP > texInfo.minBPP)
                                 {
                                     TextureImporter importer = AssetImporter.GetAtPath(AssetDatabase.GetAssetPath(texInfo.texture)) as TextureImporter;
-                                    if (importer != null)
+                                    TextureImporterFormat newFormat = texInfo.hasAlpha || importer.textureType == TextureImporterType.NormalMap ?
+                                        TextureImporterFormat.BC7 : TextureImporterFormat.DXT1;
+                                    string savedSize = AvatarEvaluator.ToMebiByteString(texInfo.size - TextureToBytesUsingBPP(texInfo.texture, BPP[newFormat]));
+                                    if (GUILayout.Button($"{newFormat} => Save {savedSize}", GUILayout.Width(200)))
                                     {
-                                        TextureImporterFormat newFormat = texInfo.hasAlpha || importer.textureType == TextureImporterType.NormalMap ?
-                                            TextureImporterFormat.BC7 : TextureImporterFormat.DXT1;
-                                        string savedSize = AvatarEvaluator.ToMebiByteString(texInfo.size - TextureToBytesUsingBPP(texInfo.texture, BPP[newFormat]));
-                                        if (GUILayout.Button($"{newFormat} => Save {savedSize}", GUILayout.Width(200)))
+                                        importer.SetPlatformTextureSettings(new TextureImporterPlatformSettings()
                                         {
-                                            importer.SetPlatformTextureSettings(new TextureImporterPlatformSettings()
-                                            {
-                                                name = "PC",
-                                                overridden = true,
-                                                format = newFormat,
-                                                maxTextureSize = texInfo.texture.width,
-                                                compressionQuality = 100
-                                            });
-                                            importer.SaveAndReimport();
-                                            Calc(_avatar);
-                                        }
+                                            name = "PC",
+                                            overridden = true,
+                                            format = newFormat,
+                                            maxTextureSize = texInfo.texture.width,
+                                            compressionQuality = 100
+                                        });
+                                        importer.SaveAndReimport();
+                                        Calc(_avatar);
                                     } else {
                                         GUILayout.Space(200);
                                     }

--- a/Editor/VRAM Check/TextureVRAM.cs
+++ b/Editor/VRAM Check/TextureVRAM.cs
@@ -379,21 +379,26 @@ namespace Thry.AvatarHelpers
                                 if(texInfo.texture is Texture2D && texInfo.BPP > texInfo.minBPP)
                                 {
                                     TextureImporter importer = AssetImporter.GetAtPath(AssetDatabase.GetAssetPath(texInfo.texture)) as TextureImporter;
-                                    TextureImporterFormat newFormat = texInfo.hasAlpha || importer.textureType == TextureImporterType.NormalMap ? 
-                                        TextureImporterFormat.BC7 : TextureImporterFormat.DXT1;
-                                    string savedSize = AvatarEvaluator.ToMebiByteString(texInfo.size - TextureToBytesUsingBPP(texInfo.texture, BPP[newFormat]));
-                                    if(GUILayout.Button($"{newFormat} => Save {savedSize}", GUILayout.Width(200)))
+                                    if (importer != null)
                                     {
-                                        importer.SetPlatformTextureSettings(new TextureImporterPlatformSettings()
+                                        TextureImporterFormat newFormat = texInfo.hasAlpha || importer.textureType == TextureImporterType.NormalMap ?
+                                            TextureImporterFormat.BC7 : TextureImporterFormat.DXT1;
+                                        string savedSize = AvatarEvaluator.ToMebiByteString(texInfo.size - TextureToBytesUsingBPP(texInfo.texture, BPP[newFormat]));
+                                        if (GUILayout.Button($"{newFormat} => Save {savedSize}", GUILayout.Width(200)))
                                         {
-                                            name = "PC",
-                                            overridden = true,
-                                            format = newFormat,
-                                            maxTextureSize = texInfo.texture.width,
-                                            compressionQuality = 100
-                                        });
-                                        importer.SaveAndReimport();
-                                        Calc(_avatar);
+                                            importer.SetPlatformTextureSettings(new TextureImporterPlatformSettings()
+                                            {
+                                                name = "PC",
+                                                overridden = true,
+                                                format = newFormat,
+                                                maxTextureSize = texInfo.texture.width,
+                                                compressionQuality = 100
+                                            });
+                                            importer.SaveAndReimport();
+                                            Calc(_avatar);
+                                        }
+                                    } else {
+                                        GUILayout.Space(200);
                                     }
                                 }else
                                 {


### PR DESCRIPTION
### Final Product
![image](https://user-images.githubusercontent.com/75397200/226482134-8a883f9e-5430-4433-a4fa-6e97877053d8.png)

### Fixes:
- fixed nullreferencexception when checking compression type for data textures
- fixed a typo at the top of the ui => "video memeory" -> "video memory" (idk if MEMEory was intentional but there it is ;)

### Feature Additions:
- added an option to view materials using a specific texture
![image](https://user-images.githubusercontent.com/75397200/226481420-5b75ac98-24b4-4a14-9339-c087254f5311.png)

- added a link to the texture compression documentation when clicking on compression type
- added a message informing the user if a texture is used in a material swap and/or if it is not compressable (adds an info icon with subtext)
![image](https://user-images.githubusercontent.com/75397200/226481485-d085a620-141a-442b-9370-1c7ed40ff9c8.png)

- added confirm dialog to compresson change
![image](https://user-images.githubusercontent.com/75397200/226481520-d6ee635e-ab34-451a-8a71-4b1f1a40038e.png)

- added a progress bar to the calculation function - noticed that on lower end systems with large models, unity would hitch for a while, making some think unity had crashed

### UI Changes:
- changed some widths and heights of the gui
- changed some spacing in messages for easier reading on smaller monitors
- moved around some scroll views to make large amounts of information easier to navigate for the end user
- moved the vram size text to the left of its texture object for easier readability (from feedback)
![image](https://user-images.githubusercontent.com/75397200/226481602-ea8a30e7-db47-4de8-8451-8eff39e8b19b.png)